### PR TITLE
fix: change pageNum when click goNext() or goPrevious() button

### DIFF
--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -51,6 +51,7 @@
             return;
           }
           scope.pageToDisplay = scope.pageToDisplay - 1;
+          scope.pageNum = scope.pageNum - 1;
           scope.renderPage(scope.pageToDisplay);
         };
 
@@ -59,6 +60,7 @@
             return;
           }
           scope.pageToDisplay = scope.pageToDisplay + 1;
+          scope.pageNum = scope.pageNum + 1;
           scope.renderPage(scope.pageToDisplay);
         };
 


### PR DESCRIPTION
I am trying this great directive, but I get a problem with page numbering.
When I click the goNext() or goPrevious() button, pageNum doesn't change.
I found this code has been disappeared 2 months ago: scope.pageNum = scope.pageNum + 1;

So, I add this code; it works well.
