### PR TITLE
Adds $window dependency injection done with [] format

### DIFF
--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -3,7 +3,7 @@
 
   'use strict';
 
-  angular.module('pdf', []).directive('ngPdf', function($window) {
+  angular.module('pdf', []).directive('ngPdf', ['$window', function($window) {
     return {
       restrict: 'E',
       templateUrl: function(element, attr) {
@@ -116,6 +116,6 @@
 
       }
     };
-  });
+  }]);
 
 })();


### PR DESCRIPTION
Hey great directive ;-)

I've got a "$aProvider is not defined" error due to unresolved dependency when minifying the code. The solution is pretty simple: you just use [ ] syntax to do explicit dependency injection. This avoids problems when someone includes the directive code and then minifies everything into a single file.

Cheers !