### PR TITLE
Add http headers

### DIFF
--- a/.idea/angularjs-pdf.iml
+++ b/.idea/angularjs-pdf.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
+</project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" />
+</project>
+

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/angularjs-pdf.iml" filepath="$PROJECT_DIR$/.idea/angularjs-pdf.iml" />
+    </modules>
+  </component>
+</project>
+

--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,0 +1,5 @@
+<component name="DependencyValidationManager">
+  <state>
+    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
+  </state>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>
+

--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -12,7 +12,7 @@
       link: function(scope, element, attrs) {
         var url = scope.pdfUrl,
           pdfDoc = null,
-          pageNum = 1,
+          pageNum = (attrs.page ? attrs.page : 1),
           scale = (attrs.scale ? attrs.scale : 1),
           canvas = (attrs.canvasid ? document.getElementById(attrs.canvasid) : document.getElementById('pdf-canvas')),
           ctx = canvas.getContext('2d'),

--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -10,9 +10,9 @@
         return attr.templateUrl ? attr.templateUrl : 'partials/viewer.html'
       },
       link: function(scope, element, attrs) {
-        var url = scope.pdfUrl,
+        var src = scope.src,
           pdfDoc = null,
-          pageNum = (attrs.page ? attrs.page : 1),
+          pageNum = (attrs.pageNum ? attrs.pageNum : 1),
           scale = (attrs.scale ? attrs.scale : 1),
           canvas = (attrs.canvasid ? document.getElementById(attrs.canvasid) : document.getElementById('pdf-canvas')),
           ctx = canvas.getContext('2d'),
@@ -86,7 +86,7 @@
           }
         };
 
-        PDFJS.getDocument(url, null, null, scope.onProgress).then(
+        PDFJS.getDocument(src, null, null, scope.onProgress).then(
           function(_pdfDoc) {
             if (typeof scope.onLoad === 'function' ) {
               scope.onLoad();

--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -10,7 +10,9 @@
         return attr.templateUrl ? attr.templateUrl : 'partials/viewer.html'
       },
       link: function(scope, element, attrs) {
-        var src = scope.src,
+        var url = scope.pdfUrl,
+          httpHeaders = scope.httpHeaders,
+          docInitParams = (httpHeaders ? {url: url, httpHeaders: httpHeaders} : url),
           pdfDoc = null,
           pageNum = (attrs.pageNum ? attrs.pageNum : 1),
           scale = (attrs.scale ? attrs.scale : 1),
@@ -86,7 +88,7 @@
           }
         };
 
-        PDFJS.getDocument(src, null, null, scope.onProgress).then(
+        PDFJS.getDocument(docInitParams, null, null, scope.onProgress).then(
           function(_pdfDoc) {
             if (typeof scope.onLoad === 'function' ) {
               scope.onLoad();


### PR DESCRIPTION
instead of rename pdfUrl to src (to make this variable more general in order to use it not just as url string), maybe it should be just added 'httpHeaders' to scope... I don't know which approach you'll like more or maybe even no one, but I think not only I may need httpHeaders while getting the document from the server