### PR TITLE
fix(bower): removing options in .bowerrc to avoid JSON logs

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,3 @@
 {
-  "directory": "bower_components",
-  "json": "bower.json"
+  "directory": "bower_components"
 }


### PR DESCRIPTION
now bower has a problem with JSON log if a "json" property is provided
in .bowerrc

ref: https://github.com/bower/bower/issues/2245#issuecomment-208549981