### PR TITLE
Multiple instances within same page do not load (rhyskoedijk, issue #1)

### DIFF
--- a/src/angular-pdf.js
+++ b/src/angular-pdf.js
@@ -4,9 +4,6 @@
   'use strict';
 
   angular.module('pdf', []).directive('ngPdf', [ '$window', function($window) {
-    var renderTask = null;
-    var pdfLoaderTask = null;
-    var debug = false;
 
     var backingScale = function(canvas) {
       var ctx = canvas.getContext('2d');
@@ -29,6 +26,7 @@
       canvas.getContext('2d').setTransform(ratio, 0, 0, ratio, 0, 0);
       return canvas;
     };
+
     return {
       restrict: 'E',
       templateUrl: function(element, attr) {
@@ -42,10 +40,11 @@
         var pageToDisplay = isFinite(attrs.page) ? parseInt(attrs.page) : 1;
         var pageFit = attrs.scale === 'page-fit';
         var scale = attrs.scale > 0 ? attrs.scale : 1;
-        var canvasid = attrs.canvasid || 'pdf-canvas';
-        var canvas = document.getElementById(canvasid);
-
-        debug = attrs.hasOwnProperty('debug') ? attrs.debug : false;
+        var canvasClassName = attrs.canvasClassName || 'pdfCanvas';
+        var canvas = element[0].getElementsByClassName(canvasClassName)[0];
+        var renderTask = null;
+        var pdfLoaderTask = null;
+        var debug = attrs.hasOwnProperty('debug') ? attrs.debug : false;
         var creds = attrs.usecredentials;
         var ctx = canvas.getContext('2d');
         var windowEl = angular.element($window);


### PR DESCRIPTION
```
allow multiple instance within the same view
locate canvas by class name rather than id
```

**As a** developer
**I want** to have two or more instances of PDF.js within the same view
**So that** I show two PDFs side-by-side

The main stumbling blocks I encountered:

*  **Problem:** `renderTask` and `pdfLoaderTask` are global (to the module), loading/rendering a second instance causes the first instance to be cancelled.
**Solution:** scope the variables to the directive instance

* **Problem**`canvasid` cannot be used with angular bindings to generate unique ids because the directive link function runs before bindings are evaluated within the template containing the canvas.
**Solution** resolve the canvas element using a class name rather than id, there should only be one `pdfCanvas` element within the template and this also removes the need for the developer to specify a `canvasid` attribute on the directive.

Original Issue:
https://github.com/rhyskoedijk/angularjs-pdf/issues/1
