### PR TITLE
webpack: fixing use of istanbul plugin only for test builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,9 +62,9 @@ var config = {
         presets: [
           "latest",
         ],
-        plugins: [
+        plugins: isTest ? [
           "istanbul"
-        ]
+        ] : undefined
       }
     }
     ],


### PR DESCRIPTION
Ref. #186 