### PR TITLE
export default module.name

### DIFF
--- a/src/angular-pdf.module.js
+++ b/src/angular-pdf.module.js
@@ -5,3 +5,5 @@ export const Pdf = angular
   .module('pdf', [])
   .directive('ngPdf', NgPdf)
   .name;
+
+export default Pdf;


### PR DESCRIPTION
export default module.name is a best prectice for angular modules

This allows you to import the module in this way:
```JavaScript
import ngPdf from 'angular-pdf'; // ES6-modules
var ngPdf = require('angular-pdf'); // CommonJS
```

Instead of:
```JavaScript
import { Pdf as ngPdf } from 'angular-pdf'; // ES6-modules
var ngPdf = require('angular-pdf').Pdf; // CommonJS
```
