### PR TITLE
#221 PDFJS is not defined working fix, compatible with latest pdf.js release

### DIFF
--- a/dist/angular-pdf.js
+++ b/dist/angular-pdf.js
@@ -89,6 +89,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 "use strict";
 
+var PDFJS = pdfjsLib;
 
 Object.defineProperty(exports, "__esModule", {
   value: true


### PR DESCRIPTION
PDFJS name is completely removed in latest pdf.js release. More info here:
https://github.com/mozilla/pdf.js/pull/9493